### PR TITLE
Feature: support optional env parameter for MCP server config

### DIFF
--- a/agent/mcp_demo/demo.py
+++ b/agent/mcp_demo/demo.py
@@ -62,9 +62,10 @@ class MCPClient:
         for mcp_name, mcp_config in self.config.items():
             server_params = StdioServerParameters(
                 # 服务器执行的命令，这里我们使用 uv 来运行 web_search.py
-                command=mcp_config["command"],
+                command = mcp_config["command"],
                 # 运行的参数
-                args=mcp_config["args"]
+                args = mcp_config["args"],
+                env = mcp_config.get("env", None)
             )
             async with stdio_client(server_params) as (read, write):
                 async with ClientSession(read, write) as session:


### PR DESCRIPTION
- Add env argument to StdioServerParameters in MCPClient initialization
- Allow each server in mcp_config to specify an env field (e.g., for gitee server tokens)
- If env is not set, default to None for backward compatibility
- Improves flexibility for integrating MCP servers requiring environment variables